### PR TITLE
Added tests for circular linked lists

### DIFF
--- a/models/circular_linked_list_test.go
+++ b/models/circular_linked_list_test.go
@@ -2,6 +2,27 @@ package models
 
 import "testing"
 
+func TestMakeCircular(t *testing.T) {
+
+	testCases := []struct {
+		Data       []int
+		IsCircular bool
+	}{
+		{Data: []int{}, IsCircular: false},
+		{Data: []int{1}, IsCircular: true},
+		{Data: []int{1, 2, 3}, IsCircular: true},
+	}
+
+	for _, c := range testCases {
+		n := CircularLinkedList{}
+		n.MakeCircular(c.Data)
+
+		if c.IsCircular != n.IsCircular() {
+			t.Fatalf("expected circular: %v, but got: %v", c.IsCircular, n.IsCircular())
+		}
+	}
+}
+
 func TestIsCircular(t *testing.T) {
 	n := CircularLinkedList{}
 
@@ -22,6 +43,7 @@ func TestIsCircular(t *testing.T) {
 		t.Fatalf("Should have detected circular list")
 	}
 }
+
 func TestAddNode(t *testing.T) {
 
 	nonCircular := CircularLinkedList{}


### PR DESCRIPTION
## What this PR does

Adds a test for circular linked lists

## How to test this PR?

You can run this like so: 

```bash

/usr/local/opt/go/libexec/bin/go tool test2json -t /Users/rexposadas/Library/Caches/JetBrains/GoLand2023.2/tmp/GoLand/___TestMakeCircular_in_github_com_tanggol69_linked_list_tree_doubly_linked_list_models.test -test.v -test.paniconexit0 -test.run ^\QTestMakeCircular\E$
=== RUN   TestMakeCircular
The linkedlist is not circular
The linkedlist is circular
The linkedlist is circular
--- PASS: TestMakeCircular (0.00s)
PASS

```



